### PR TITLE
Changed facet order for Record_type / Primary_type in _only_facets.html.erb

### DIFF
--- a/public/views/shared/_only_facets.html.erb
+++ b/public/views/shared/_only_facets.html.erb
@@ -1,0 +1,78 @@
+<% unless @facets.blank? %>
+<h3><%= t('search_results.filter.add')%>: </h3>
+<dl id="facets">
+
+  <%
+    preferred_facet_order = %w(repository primary_type agents subjects langcode)
+    ordered_facet_types = @facets.keys.sort{|a,b|
+      if preferred_facet_order.include?(a) && preferred_facet_order.include?(b)
+        preferred_facet_order.index(a) <=> preferred_facet_order.index(b)
+      elsif preferred_facet_order.include?(a)
+        -1
+      elsif preferred_facet_order.include?(b)
+        1
+      else
+        0
+      end
+    }
+  %>
+
+  <% max_facets_on_load = 5
+    ordered_facet_types.each do |type| %>
+    <%
+      facet_group = @facets.fetch(type, false)
+
+      if type == 'primary_type'
+        # Define the desired order by label
+        desired_order = [
+          "Collection",
+          "Digital Record",
+          "Archival Object",
+          "Subject",
+          "Person",
+          "Organization",
+          "Family",
+          "Unprocessed Material",
+          "Digital Object Component",
+          "Record Group",
+          "Library"
+        ]
+
+        # Create a hash mapping labels to their desired position
+        order_map = desired_order.each_with_index.to_h { |label, index| [label, index] }
+
+        # Sort the facet_group based on the desired order
+        # Items not in the desired order will appear at the end
+        ordered_facets = facet_group.sort_by do |facet|
+          order_map[facet.label] || Float::INFINITY
+        end
+      end
+    %>
+    <div id="<%= t("search_results.filter.#{type}").downcase %>-facet">
+      <dt class='mb-2 mt-3'><%= t("search_results.filter.#{type}") %></dt>
+      <% if facet_group.length <= max_facets_on_load %>
+        <% facet_group.each do |facet| %>
+          <%= render partial: 'shared/facet_description', locals: { type: type, facet: facet } %>
+        <% end %>
+      <% else %>
+        <% facet_group.slice(0, max_facets_on_load).each do |facet| %>
+          <%= render partial: 'shared/facet_description', locals: { type: type, facet: facet } %>
+        <% end %>
+        <div class="more-facets">
+          <button type="button" class="more-facets__more mb-1 btn btn-sm">
+            <%= t('search_results.more_facets') %> <i class="fa fa-chevron-down"></i>
+          </button>
+          <div class="more-facets__facets">
+            <% facet_group.slice(max_facets_on_load, facet_group.length - 1).each do |facet| %>
+              <%= render partial: 'shared/facet_description', locals: { type: type, facet: facet } %>
+            <% end %>
+          </div>
+          <button type="button" class="more-facets__less mb-1 btn btn-sm">
+            <%= t('search_results.fewer_facets') %> <i class="fa fa-chevron-up"></i>
+          </button>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
+</dl>
+<% end %>


### PR DESCRIPTION
This change should address the longstanding request in Asana to reorder record types. Unlike a prior attempt at a fix, this is designed around the plugin first and foremost, and therefore should work properly in v4.1.1